### PR TITLE
BugFix: customRole to use TenantId as unique identifier

### DIFF
--- a/modules/iom/azureRoleDefinitionAssignableScope.bicep
+++ b/modules/iom/azureRoleDefinitionAssignableScope.bicep
@@ -3,7 +3,7 @@ targetScope = 'subscription'
 param customRoleName string
 
 resource existingCustomRoleDefinition 'Microsoft.Authorization/roleDefinitions@2022-04-01' existing = {
-  name: guid(customRoleName, subscription().id)
+  name: guid(customRoleName, tenant().tenantId)
 }
 
 output assignableScopes array = existingCustomRoleDefinition.properties.assignableScopes

--- a/modules/iom/azureSubscriptionExistingRoleDefinition.bicep
+++ b/modules/iom/azureSubscriptionExistingRoleDefinition.bicep
@@ -27,7 +27,7 @@ module assignableScope 'azureRoleDefinitionAssignableScope.bicep' = {
     }
 
 resource modifyExistingCustomRoleDefinition 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
-  name: guid(customRole.roleName, subscription().id)
+  name: guid(customRole.roleName, tenant().tenantId)
   properties: {
     assignableScopes: union(assignableScope.outputs.assignableScopes,[subscriptionId])
     description: customRole.roleDescription

--- a/modules/iom/azureSubscriptionRoleDefinition.bicep
+++ b/modules/iom/azureSubscriptionRoleDefinition.bicep
@@ -17,7 +17,7 @@ var customRole = {
 }
 
 resource customRoleDefinition 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
-  name: guid(customRole.roleName, subscription().id,'test')
+  name: guid(customRole.roleName, tenant().tenantId)
   properties: {
     assignableScopes: [subscription().id]
     description: customRole.roleDescription


### PR DESCRIPTION
Fixed an issue where the customRole created could not be identified properly. customRole now uses the TenantId as unique identifier.