### PR TITLE
Feature Request: adding activity log diagnostic settings to all active subscriptions

### DIFF
--- a/cs-deployment-managementGroup.bicep
+++ b/cs-deployment-managementGroup.bicep
@@ -97,8 +97,11 @@ param deployIOA bool = true
 #disable-next-line no-unused-params
 param enableAppInsights bool = false
 
-@description('Deploy Activity Log Diagnostic Settings. Defaults to true.')
+@description('Deploy Activity Log Diagnostic Settings to all active Azure subscriptions. Defaults to true.')
 param deployActivityLogDiagnosticSettings bool = true
+
+@description('Deploy Activity Log Diagnostic Settings policy. Defaults to true.')
+param deployActivityLogDiagnosticSettingsPolicy bool = true
 
 @description('Deploy Entra Log Diagnostic Settings. Defaults to true.')
 param deployEntraLogDiagnosticSettings bool = true
@@ -138,6 +141,7 @@ module ioaAzureSubscription 'modules/cs-ioa-deployment.bicep' = if (deployIOA &&
   name: '${deploymentNamePrefix}-ioa-azureSubscription-${deploymentNameSuffix}'
   scope: subscription(defaultSubscriptionId) // DO NOT CHANGE
   params: {
+    targetScope: targetScope
     falconCID: falconCID
     falconClientId: falconClientId
     falconClientSecret: falconClientSecret
@@ -173,7 +177,7 @@ module activityLogDiagnosticSettingsDeployment 'modules/cs-ioa-diagnosticsetting
   ]
 }
 
-module ioaAzurePolicyAssignment 'modules/ioa/activityLogPolicy.bicep' = if (deployIOA && targetScope == 'ManagementGroup' && deployActivityLogDiagnosticSettings) {
+module activityLogDiagnosticSettingsPolicyAssignment 'modules/ioa/activityLogPolicy.bicep' = if (deployIOA && targetScope == 'ManagementGroup' && deployActivityLogDiagnosticSettingsPolicy) {
   name: '${deploymentNamePrefix}-ioa-azurePolicyAssignment-${deploymentNameSuffix}'
   scope: managementGroup()
   params: {

--- a/cs-deployment-subscription.bicep
+++ b/cs-deployment-subscription.bicep
@@ -126,7 +126,8 @@ module iomAzureSubscription 'modules/iom/azureSubscription.bicep' = if (deployIO
 module ioaAzureSubscription 'modules/cs-ioa-deployment.bicep' = if (deployIOA && targetScope == 'Subscription') {
   name: '${deploymentNamePrefix}-ioa-azureSubscription-${deploymentNameSuffix}'
   scope: subscription(defaultSubscriptionId)
-  params:{
+  params: {
+    targetScope: targetScope
     falconCID: falconCID
     falconClientId: falconClientId
     falconClientSecret: falconClientSecret

--- a/modules/cs-ioa-deployment.bicep
+++ b/modules/cs-ioa-deployment.bicep
@@ -340,6 +340,16 @@ module entraLogFunction 'ioa/functionApp.bicep' = {
   ]
 }
 
+/* Create user-assigned Managed Identity to be used for getting all Azure Subscriptions */
+module activityLogIdentity 'ioa/activityLogIdentity.bicep' = if (deployActivityLogDiagnosticSettings) {
+  name: '${deploymentNamePrefix}-activityLogIdentity-${deploymentNameSuffix}'
+  scope: scope
+  params: {
+    activityLogIdentityName: 'cs-activityLogDeployment-${defaultSubscriptionId}'
+  }
+}
+
+/* Deploy Activity Log Diagnostic Settings for current Azure subscription */
 module activityDiagnosticSettings 'ioa/activityLog.bicep' = if (deployActivityLogDiagnosticSettings) {
   name:  '${deploymentNamePrefix}-activityLog-${deploymentNameSuffix}'
   scope: subscription(subscriptionId)
@@ -375,3 +385,5 @@ module setAzureDefaultSubscription 'ioa/defaultSubscription.bicep' = {
 output eventHubAuthorizationRuleId string = eventHub.outputs.eventHubAuthorizationRuleId
 output activityLogEventHubName string = eventHub.outputs.activityLogEventHubName
 output entraLogEventHubName string = eventHub.outputs.entraLogEventHubName
+output activityLogIdentityId string = activityLogIdentity.outputs.activityLogIdentityId
+output activityLogIdentityPrincipalId string = activityLogIdentity.outputs.activityLogIdentityPrincipalId

--- a/modules/cs-ioa-deployment.bicep
+++ b/modules/cs-ioa-deployment.bicep
@@ -8,6 +8,13 @@ targetScope = 'subscription'
 */
 
 /* Parameters */
+@description('Targetscope of the IOM integration.')
+@allowed([
+  'ManagementGroup'
+  'Subscription'
+])
+param targetScope string
+
 @description('The location for the resources deployed in this solution.')
 param location string = deployment().location
 
@@ -341,7 +348,7 @@ module entraLogFunction 'ioa/functionApp.bicep' = {
 }
 
 /* Create user-assigned Managed Identity to be used for getting all Azure Subscriptions */
-module activityLogIdentity 'ioa/activityLogIdentity.bicep' = if (deployActivityLogDiagnosticSettings) {
+module activityLogIdentity 'ioa/activityLogIdentity.bicep' = if (deployActivityLogDiagnosticSettings && targetScope == 'ManagementGroup') {
   name: '${deploymentNamePrefix}-activityLogIdentity-${deploymentNameSuffix}'
   scope: scope
   params: {
@@ -350,7 +357,7 @@ module activityLogIdentity 'ioa/activityLogIdentity.bicep' = if (deployActivityL
 }
 
 /* Deploy Activity Log Diagnostic Settings for current Azure subscription */
-module activityDiagnosticSettings 'ioa/activityLog.bicep' = if (deployActivityLogDiagnosticSettings) {
+module activityDiagnosticSettings 'ioa/activityLog.bicep' = {
   name:  '${deploymentNamePrefix}-activityLog-${deploymentNameSuffix}'
   scope: subscription(subscriptionId)
   params: {

--- a/modules/cs-ioa-diagnosticsettings-deployment.bicep
+++ b/modules/cs-ioa-diagnosticsettings-deployment.bicep
@@ -1,0 +1,61 @@
+targetScope = 'subscription'
+
+/*
+  This Bicep template deploys Azure Activity Log Diagnostic Settings
+  to existing Azure subscriptions in the current Entra Id tenant
+  to enable CrowdStrike Indicator of Attack (IOA) assessment.
+
+  Copyright (c) 2024 CrowdStrike, Inc.
+*/
+
+/* Parameters */
+@minLength(36)
+@maxLength(36)
+@description('Subscription Id of the default Azure Subscription.')
+param defaultSubscriptionId string
+
+@description('The prefix to be added to the deployment name.')
+param deploymentNamePrefix string = 'cs'
+
+@description('The suffix to be added to the deployment name.')
+param deploymentNameSuffix string = utcNow()
+
+@description('Name of the resource group.')
+param resourceGroupName string = 'cs-ioa-group' // DO NOT CHANGE
+
+@description('Id of the user-assigned Managed Identity with Reader access to all Azure Subscriptions.')
+param activityLogIdentityId string
+
+@description('Event Hub Authorization Rule Id.')
+param eventHubAuthorizationRuleId string
+
+@description('Event Hub Name.')
+param eventHubName string
+
+/* Variables */
+var scope = az.resourceGroup(resourceGroup.name)
+
+/* Resource Deployment */
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2024-03-01' existing = {
+  name: resourceGroupName
+  scope: subscription(defaultSubscriptionId)
+}
+
+/* Get all enabled Azure subscriptions in the current Entra Id tenant */
+module azureSubscriptions 'ioa/azureSubscriptions.bicep' = {
+  name: '${deploymentNamePrefix}-ioa-azureSubscriptions-${deploymentNameSuffix}'
+  scope: scope
+  params: {
+    activityLogIdentityId: activityLogIdentityId
+  }
+}
+
+module activityLogDiagnosticSettings 'ioa/activityLogDiagnosticSettings.bicep' = {
+  name: '${deploymentNamePrefix}-ioa-activityLogDiagnosticSettings-${deploymentNameSuffix}'
+  scope: subscription(defaultSubscriptionId)
+  params: {
+    subscriptionIds: azureSubscriptions.outputs.activeAzureSubscriptions
+    eventHubAuthorizationRuleId: eventHubAuthorizationRuleId
+    eventHubName: eventHubName
+  }
+}

--- a/modules/ioa/activityLogDiagnosticSettings.bicep
+++ b/modules/ioa/activityLogDiagnosticSettings.bicep
@@ -1,0 +1,21 @@
+targetScope = 'subscription'
+
+@description('Azure subscription Ids to configure Activity Log diagnostic settings.')
+param subscriptionIds array
+
+@description('Event Hub Authorization Rule Id.')
+param eventHubAuthorizationRuleId string
+
+@description('Event Hub Name.')
+param eventHubName string
+
+module activityDiagnosticSettings 'activityLog.bicep' = [
+  for subscriptionId in subscriptionIds: {
+    name: 'cs-ioa-activityLogDiagnosticSettings'
+    scope: subscription(subscriptionId)
+    params: {
+      eventHubAuthorizationRuleId: eventHubAuthorizationRuleId
+      eventHubName: eventHubName
+    }
+  }
+]

--- a/modules/ioa/activityLogIdentity.bicep
+++ b/modules/ioa/activityLogIdentity.bicep
@@ -1,0 +1,14 @@
+param activityLogIdentityName string
+param location string = resourceGroup().location
+param tags object = {}
+
+resource activityLogIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: activityLogIdentityName
+  location: location
+  tags: tags
+}
+
+output activityLogIdentityId string = activityLogIdentity.id
+output activityLogIdentityName string = activityLogIdentity.name
+output activityLogIdentityClientId string = activityLogIdentity.properties.clientId
+output activityLogIdentityPrincipalId string = activityLogIdentity.properties.principalId

--- a/modules/ioa/activityLogIdentityRoleAssignment.bicep
+++ b/modules/ioa/activityLogIdentityRoleAssignment.bicep
@@ -1,0 +1,16 @@
+targetScope = 'managementGroup'
+
+param activityLogIdentityId string
+param activityLogIdentityPrincipalId string
+param principalType string = 'ServicePrincipal'
+
+param ReaderRoleId string = 'acdd72a7-3385-48ef-bd42-f606fba81ae7' // Reader
+
+resource activityLogIdentityRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(activityLogIdentityId, ReaderRoleId, managementGroup().id)
+  properties: {
+    roleDefinitionId: resourceId('Microsoft.Authorization/roleDefinitions', ReaderRoleId)
+    principalId: activityLogIdentityPrincipalId
+    principalType: principalType
+  }
+}

--- a/modules/ioa/azureSubscriptions.bicep
+++ b/modules/ioa/azureSubscriptions.bicep
@@ -1,0 +1,28 @@
+@description('Id of the user-assigned Managed Identity with Reader access to all Azure Subscriptions.')
+param activityLogIdentityId string
+
+resource azureSubscriptions 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
+  name: 'cs-ioa-azureSubscriptions-${tenant().tenantId}'
+  location: resourceGroup().location
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${activityLogIdentityId}': {}
+    }
+  }
+  kind: 'AzurePowerShell'
+  properties: {
+    azPowerShellVersion: '12.3'
+    arguments: '-AzureTenantId ${tenant().tenantId}'
+    scriptContent: '''
+      param([string] $AzureTenantId)
+      $DeploymentScriptOutputs = @{}
+      $activeSubscriptions = Get-AzSubscription | ? {($_.State -eq "Enabled") -and ($_.TenantId -eq $AzureTenantId)} | Select-Object -ExpandProperty Id
+      $DeploymentScriptOutputs['subscriptions'] = $activeSubscriptions
+    '''
+    retentionInterval: 'PT1H'
+    cleanupPreference: 'OnSuccess'
+  }
+}
+
+output activeAzureSubscriptions array = azureSubscriptions.properties.outputs.subscriptions


### PR DESCRIPTION
This feature adds support to deploy Activity Log diagnostic settings to all active subscription in a tenant, in order to not rely on Azure Policy for existing subscriptions because of delays during compliance evaluation.