### PR TITLE
Moved activityLogIdentity module out of the cs-ioa-deployment file

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ You can use any of these methods to pass parameters:
 | `deployEntraLogDiagnosticSettings`      | no       | Deploy Entra Log Diagnostic Settings. Defaults to `true`.                                                                      |
 
 ## Resource Names
-Do not change the names of the following Azure resources as they are used for registration validation and must remain unchanged. Other resource names in the files can be changed according to your internal naming convention.
+Do not change the names of the following Azure azurresources as they are used for registration validation and must remain unchanged. Other resource names in the files can be changed according to your internal naming convention.
 - Diagnostic Setting in subscription:
    - Default name: cs-monitor-activity-to-eventhub
 - IOA Resource Group:

--- a/modules/cs-ioa-deployment.bicep
+++ b/modules/cs-ioa-deployment.bicep
@@ -347,15 +347,6 @@ module entraLogFunction 'ioa/functionApp.bicep' = {
   ]
 }
 
-/* Create user-assigned Managed Identity to be used for getting all Azure Subscriptions */
-module activityLogIdentity 'ioa/activityLogIdentity.bicep' = if (deployActivityLogDiagnosticSettings && targetScope == 'ManagementGroup') {
-  name: '${deploymentNamePrefix}-activityLogIdentity-${deploymentNameSuffix}'
-  scope: scope
-  params: {
-    activityLogIdentityName: 'cs-activityLogDeployment-${defaultSubscriptionId}'
-  }
-}
-
 /* Deploy Activity Log Diagnostic Settings for current Azure subscription */
 module activityDiagnosticSettings 'ioa/activityLog.bicep' = {
   name:  '${deploymentNamePrefix}-activityLog-${deploymentNameSuffix}'
@@ -392,5 +383,3 @@ module setAzureDefaultSubscription 'ioa/defaultSubscription.bicep' = {
 output eventHubAuthorizationRuleId string = eventHub.outputs.eventHubAuthorizationRuleId
 output activityLogEventHubName string = eventHub.outputs.activityLogEventHubName
 output entraLogEventHubName string = eventHub.outputs.entraLogEventHubName
-output activityLogIdentityId string = activityLogIdentity.outputs.activityLogIdentityId
-output activityLogIdentityPrincipalId string = activityLogIdentity.outputs.activityLogIdentityPrincipalId


### PR DESCRIPTION
Moved activityLogIdentity module out of the cs-ioa-deployment file fix an issue when trying to reference a module for an output value when the module is under a false condition